### PR TITLE
Add HTTP Caching with WebCache gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/cache
 /coverage
 /dev
 /doc

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Features
 * Access any Quandl endpoint directly.
 * Display output in various formats.
 * Save output to a file, including bulk downloads.
+* Includes a built in file cache.
 
 Usage
 --------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -138,7 +138,26 @@ $ quata url datasets/WIKI/AAPL rows:5
 # => https://www.quandl.com/api/v3/datasets/WIKI/AAPL.csv?auth_token=YOUR_KEY&rows=5
 ```
 
+Caching
+--------------------------------------------------
+
+Quata uses the [WebCache][3] gem for automatic HTTP caching.
+By default, all requests are cached for 60 minutes in the `./cache`
+directory.
+
+You can access the `WebCache` object through `quandle.cache`, so you 
+can disable it, change its directory, or change its lifetime.
+
+```ruby
+quandl = Quandl.new 'Your API Key'
+quandl.cache.disable             # Skip caching altogether
+quandl.cache.dir = 'tmp/cache'   # Change cache folder
+quandl.cache.life = 120          # Change cache life to 2 minutes
+quandl.cache.enable              # Enable caching
+```
+
 ![Quata Demo](https://raw.githubusercontent.com/DannyBen/quata/master/demo.gif "Quata Demo")
 
 [1]: https://www.quandl.com/blog/getting-started-with-the-quandl-api
 [2]: https://github.com/DannyBen/quata/blob/master/lib/quata/docopt.txt
+[3]: https://github.com/DannyBen/webcache

--- a/quata.gemspec
+++ b/quata.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'docopt', '~> 0.5'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
+  s.add_runtime_dependency 'webcache', '~> 0.1'
 
   s.add_development_dependency 'runfile', '~> 0.7'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
   s.add_development_dependency 'rspec', '~> 3.4'
-  s.add_development_dependency 'webmock', '~> 2.0'
   s.add_development_dependency 'rdoc', '~> 4.2'
   s.add_development_dependency 'byebug', '~> 9.0'
   s.add_development_dependency 'simplecov', '~> 0.11'

--- a/spec/quata/command_line_spec.rb
+++ b/spec/quata/command_line_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe CommandLine do
-  WebMock.allow_net_connect!
   let(:cli) { Quata::CommandLine.instance }
   let(:premium) { ENV['QUANDL_PREMIUM']}
 

--- a/spec/quata/quandl_queries_spec.rb
+++ b/spec/quata/quandl_queries_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe "quandl queries" do
 
-  WebMock.allow_net_connect!
   let(:quandl) { Quandl.new ENV['QUANDL_KEY'] }
   let(:premium) { ENV['QUANDL_PREMIUM']}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,7 @@ require 'rubygems'
 require 'bundler'
 Bundler.require :default, :development
 
-require 'webmock/rspec'
-
 include Quata
-
-require_relative 'support'
-include TestSupport
 
 RSpec.configure do |config|
   config.filter_run_excluding type: :premium unless ENV['QUANDL_PREMIUM']

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -1,2 +1,0 @@
-module TestSupport
-end


### PR DESCRIPTION
This PR adds a built in, hassle-free caching using the newly created [WebCache gen](https://github.com/DannyBen/webcache).

By dafault, `Quata` adopts the default values from `WebCache`, but can be changed with ease by accessing the `quandl.cache` property, which is the `WebCache` object itself.

Also - removed `WebMock` dev dependency.

Closes #2 
