### PR TITLE
Allow library and command line to be configured for caching options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Features
 * Access any Quandl endpoint directly.
 * Display output in various formats.
 * Save output to a file, including bulk downloads.
-* Includes a built in file cache.
+* Includes a built in file cache (disabled by default).
 
 Usage
 --------------------------------------------------
@@ -143,19 +143,35 @@ Caching
 --------------------------------------------------
 
 Quata uses the [WebCache][3] gem for automatic HTTP caching.
-By default, all requests are cached for 60 minutes in the `./cache`
-directory.
+To take the path of least surprises, caching is disabled by default.
 
-You can access the `WebCache` object through `quandl.cache`, so you 
-can disable it, change its directory, or change its lifetime.
+You can enable and customize it by either passing options on 
+initialization, or by accessing the `WebCache` object directly at 
+a later stage.
 
 ```ruby
+quandl = Quandl.new 'Your API Key', use_cache: true
+quandl = Quandl.new 'Your API Key', use_cache: true, cache_dir: 'tmp'
+quandl = Quandl.new 'Your API Key', use_cache: true, cache_life: 120
+
+# or 
+
 quandl = Quandl.new 'Your API Key'
-quandl.cache.disable             # Skip caching altogether
+quandl.cache.enable
 quandl.cache.dir = 'tmp/cache'   # Change cache folder
 quandl.cache.life = 120          # Change cache life to 2 minutes
-quandl.cache.enable              # Enable caching
 ```
+
+To enable caching for the command line, simply set one or both of 
+these environment variables:
+
+```
+$ export QUANDL_CACHE_DIR=cache
+$ export QUANDL_CACHE_LIFE=120
+$ quata get datasets/WIKI/AAPL
+# => This call will be cached
+```
+
 
 Terminalcast
 --------------------------------------------------

--- a/lib/quata/command_line.rb
+++ b/lib/quata/command_line.rb
@@ -91,7 +91,7 @@ module Quata
       result = {}
       result[:use_cache] = true
       result[:cache_dir] = cache_dir if cache_dir
-      result[:cache_life] = cache_life if cache_life
+      result[:cache_life] = cache_life.to_i if cache_life
       result
     end
 

--- a/lib/quata/command_line.rb
+++ b/lib/quata/command_line.rb
@@ -12,7 +12,7 @@ module Quata
     attr_reader :quandl
 
     def initialize
-      @quandl = Quandl.new api_key
+      @quandl = Quandl.new api_key, options
       @quandl.format = :csv
     end
 
@@ -86,6 +86,22 @@ module Quata
       @api_key ||= ENV['QUANDL_KEY']
     end
 
-  end
+    def options
+      return {} unless cache_dir || cache_life
+      result = {}
+      result[:use_cache] = true
+      result[:cache_dir] = cache_dir if cache_dir
+      result[:cache_life] = cache_life if cache_life
+      result
+    end
 
+    def cache_dir
+      ENV['QUANDL_CACHE_DIR']
+    end
+
+    def cache_life
+      ENV['QUANDL_CACHE_LIFE']
+    end
+
+  end
 end

--- a/lib/quata/quandl.rb
+++ b/lib/quata/quandl.rb
@@ -4,10 +4,26 @@ require 'json'
 class Quandl < Quata::WebAPI
   attr_reader :api_key
 
-  def initialize(api_key=nil, base_url=nil)
+  def initialize(api_key=nil, opts={})
+    if api_key.is_a? Hash
+      opts = api_key
+      api_key = nil
+    end
+
     @api_key = api_key
 
-    base_url ||= 'https://www.quandl.com/api/v3'
+    defaults = {
+      use_cache: false,
+      cache_dir: nil,
+      cache_life: nil,
+      base_url: 'https://www.quandl.com/api/v3'
+    }
+
+    opts = defaults.merge! opts
+
+    self.cache.disable unless opts[:use_cache]
+    self.cache.dir = opts[:cache_dir] if opts[:cache_dir]
+    self.cache.life = opts[:cache_life] if opts[:cache_life]
 
     param auth_token: api_key if api_key
     self.format = :json
@@ -20,6 +36,6 @@ class Quandl < Quata::WebAPI
       end
     end
     
-    super base_url
+    super opts[:base_url]
   end
 end

--- a/lib/quata/web_api.rb
+++ b/lib/quata/web_api.rb
@@ -8,11 +8,10 @@ module Quata
   # dynamic methods.
   class WebAPI
     attr_reader :base_url, :after_request_block
-    attr_accessor :debug, :format, :cache
+    attr_accessor :debug, :format
 
     def initialize(base_url)
       @base_url = base_url
-      @cache = WebCache.new
     end
 
     # Allow using any method as the first segment of the path
@@ -28,6 +27,10 @@ module Quata
         default_params[key] = value
         default_params.delete key if value.nil?
       end
+    end
+
+    def cache
+      @cache ||= WebCache.new
     end
 
     # Return the last HTTP error, or false if all was good

--- a/spec/quata/command_line_spec.rb
+++ b/spec/quata/command_line_spec.rb
@@ -71,6 +71,5 @@ describe CommandLine do
       end
     end
 
-
   end
 end

--- a/spec/quata/command_line_spec.rb
+++ b/spec/quata/command_line_spec.rb
@@ -4,6 +4,34 @@ describe CommandLine do
   let(:cli) { Quata::CommandLine.instance }
   let(:premium) { ENV['QUANDL_PREMIUM']}
 
+  describe '#initialize' do
+    let(:cli) { Quata::CommandLine.clone.instance }
+
+    context "without environment variables" do
+      it "has cache disabled" do
+        expect(cli.quandl.cache).not_to be_enabled
+      end
+    end
+
+    context "with CACHE_DIR" do
+      it "enables cache" do
+        ENV['QUANDL_CACHE_DIR'] = 'hello'
+        expect(cli.quandl.cache).to be_enabled
+        expect(cli.quandl.cache.dir).to eq 'hello'
+        ENV.delete 'QUANDL_CACHE_DIR'
+      end
+    end
+
+    context "with CACHE_LIFE" do
+      it "enables cache" do
+        ENV['QUANDL_CACHE_LIFE'] = '123'
+        expect(cli.quandl.cache).to be_enabled
+        expect(cli.quandl.cache.life).to eq 123
+        ENV.delete 'QUANDL_CACHE_LIFE'
+      end
+    end
+  end
+
   describe '#execute' do
     context "without arguments" do
       it "shows usage patterns" do
@@ -66,10 +94,10 @@ describe CommandLine do
     context "with an invalid path" do
       let(:command) { %W[get not_here] }
       
-      it "fails gracefully" do
+      it "fails with honor" do
         expect {cli.execute command}.to output(/400 Bad Request/).to_stdout
       end
     end
-
   end
+
 end

--- a/spec/quata/quandl_queries_spec.rb
+++ b/spec/quata/quandl_queries_spec.rb
@@ -38,7 +38,7 @@ describe "quandl queries" do
       expect(response).to match /Date,Open,High,Low,Close,Volume/
     end
 
-    it "fails gracefully" do
+    it "fails with honor" do
       response = quandl.get "no_can_do"
       expect(response).to eq '400 Bad Request'
     end

--- a/spec/quata/quandl_spec.rb
+++ b/spec/quata/quandl_spec.rb
@@ -17,9 +17,29 @@ describe Quandl do
       expect(quandl.default_params[:auth_token]).to eq '70p-53cr37'
     end
 
-    it "initializes with a different base url" do
-      quandl = Quandl.new 'key', 'http://new.quandl.com/v99'
+    it "starts with cache disabled" do
+      quandl = Quandl.new
+      expect(quandl.cache).not_to be_enabled
+    end
+
+    it "initializes with options" do
+      quandl = Quandl.new 'key', 
+        base_url: 'http://new.quandl.com/v99',
+        use_cache: true,
+        cache_dir: 'custom',
+        cache_life: 1337
+
       expect(quandl.base_url).to eq 'http://new.quandl.com/v99'
+      expect(quandl.cache.dir).to eq 'custom'
+      expect(quandl.cache.life).to eq 1337
+      expect(quandl.cache).to be_enabled
+    end
+
+    context "without a key" do
+      it "initializes with options" do
+        quandl = Quandl.new use_cache: true
+        expect(quandl.cache).to be_enabled
+      end
     end
   end
 


### PR DESCRIPTION
This PR:
- Makes cache disabled by default - path of least surprises
- Adds `options` hash to the `Quandl.new` method
- Adds configuration through environment variables to command line
- Closes #10 
