### PR TITLE
Switch to using Super Docopt

### DIFF
--- a/bin/quata
+++ b/bin/quata
@@ -3,7 +3,7 @@
 require 'quata'
 
 begin
-  Quata::CommandLine.instance.execute ARGV
+  Quata::CommandLine.execute ARGV
 rescue Quata::BadResponse => e
   STDERR.puts "#{e.class} - #{e.message}"
 end

--- a/quata.gemspec
+++ b/quata.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_runtime_dependency 'docopt', '~> 0.5'
+  s.add_runtime_dependency 'super_docopt', '~> 0.1'
   s.add_runtime_dependency 'awesome_print', '~> 1.8'
   s.add_runtime_dependency 'apicake', '~> 0.1'
 

--- a/spec/quata/command_line_spec.rb
+++ b/spec/quata/command_line_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CommandLine do
-  let(:cli) { Quata::CommandLine.instance }
+  let(:cli) { Quata::CommandLine }
   let(:premium) { ENV['QUANDL_PREMIUM']}
 
   before do


### PR DESCRIPTION
This is a minor refactoring of the `CommandLine` class, to use [Super Docopt](https://github.com/DannyBen/super_docopt) for less boiler-platey code.